### PR TITLE
Add web app and n8n workflow for Quote Assistant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+web/node_modules

--- a/README.md
+++ b/README.md
@@ -1,1 +1,62 @@
-# quote
+# Quote Assistant Deployment
+
+This repository contains a simple web application and an n8n workflow used to collect project information, query Autotask, call a Custom GPT, and archive files to SharePoint.
+
+## Prerequisites
+
+* Docker and Docker Compose
+* An existing n8n instance reachable at `https://n8n.gds-atl.app`
+* Autotask, OpenAI, and Microsoft Graph credentials configured in n8n
+* A Cloudflare Tunnel token for exposing the web interface
+* Azure AD application (client ID and tenant ID) for Microsoft sign‑in
+
+## Environment Variables
+
+Create a `.env` file or define the following variables in Portainer when deploying the stack:
+
+| Variable | Description |
+|----------|-------------|
+| `AAD_CLIENT_ID` | Azure AD application client ID |
+| `AAD_TENANT_ID` | Azure AD tenant ID |
+| `CLOUDFLARED_TOKEN` | Token for Cloudflare Tunnel |
+
+## Run the Web App
+
+```bash
+docker compose up -d --build
+```
+
+The web interface will be available on port `3000` locally and via the Cloudflare tunnel at `https://quote.gds-atl.app` once DNS is configured.
+
+## Import the n8n Workflow
+
+1. Log in to `https://n8n.gds-atl.app`.
+2. From the **Workflows** view, choose **Import from File** and select `n8n-workflow.json`.
+3. Assign credentials to the following nodes:
+   * **Autotask Lookup** – Autotask API credentials
+   * **OpenAI** – API key with access to the Custom GPT
+   * **Upload to SharePoint** – Microsoft Graph credentials with permission to write to the target site
+4. Activate the workflow and note the webhook URL (`/webhook/project`).
+
+## Usage
+
+1. Open `https://quote.gds-atl.app`.
+2. Sign in with Microsoft.
+3. Enter project details and optionally upload files.
+4. Submitted information is sent to n8n, which verifies the customer in Autotask, queries the Custom GPT, stores files in SharePoint, and returns GPT output to the web page.
+
+## Development
+
+The web service runs a small Node/Express server that injects environment variables into a static HTML page using MSAL for Azure AD sign‑in.
+
+```bash
+cd web
+npm install
+npm start
+```
+
+## Files
+
+* `docker-compose.yml` – Stack definition for the web app and Cloudflare tunnel
+* `web/` – Source for the front‑end server
+* `n8n-workflow.json` – Importable workflow for n8n

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.8"
+services:
+  web:
+    build: ./web
+    environment:
+      - N8N_WEBHOOK_URL=https://n8n.gds-atl.app/webhook/project
+      - AAD_CLIENT_ID=${AAD_CLIENT_ID}
+      - AAD_TENANT_ID=${AAD_TENANT_ID}
+    ports:
+      - "3000:3000"
+    restart: unless-stopped
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    command: tunnel run
+    environment:
+      - TUNNEL_TOKEN=${CLOUDFLARED_TOKEN}
+    restart: unless-stopped

--- a/n8n-workflow.json
+++ b/n8n-workflow.json
@@ -1,0 +1,129 @@
+{
+  "name": "Quote Assistant Workflow",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "project",
+        "responseMode": "lastNode",
+        "options": {}
+      },
+      "id": "1",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "url": "=https://webservicesX.autotask.net/atservicesrest/v1.0/Contacts?$filter=email%20eq%20'{{$json[\"userEmail\"]}}'",
+        "responseFormat": "json",
+        "options": {}
+      },
+      "id": "2",
+      "name": "Autotask Lookup",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 2,
+      "position": [480, 300]
+    },
+    {
+      "parameters": {
+        "url": "https://api.openai.com/v1/chat/completions",
+        "method": "POST",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "openAiApi",
+        "jsonParameters": true,
+        "options": {},
+        "body": {
+          "model": "g-68b63cdfae348191ab5a3632e835d24c-gds-low-voltage-quoting-assistant",
+          "messages": [
+            {
+              "role": "user",
+              "content": "={{$json[\"prompt\"]}}"
+            }
+          ]
+        }
+      },
+      "id": "3",
+      "name": "OpenAI",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 2,
+      "position": [720, 300]
+    },
+    {
+      "parameters": {
+        "url": "=https://graph.microsoft.com/v1.0/sites/{site-id}/drive/root:/Quotes/{{$json[\"userEmail\"]}}/{{Date.now()}}-file:/content",
+        "method": "PUT",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "microsoftGraphApi",
+        "sendBinaryData": true,
+        "binaryPropertyName": "file"
+      },
+      "id": "4",
+      "name": "Upload to SharePoint",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 2,
+      "position": [960, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ {\"gptOutput\": $json[\"choices\"][0][\"message\"][\"content\"]} }}",
+        "options": {}
+      },
+      "id": "5",
+      "name": "Respond to Webhook",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [1200, 300]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Autotask Lookup",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Autotask Lookup": {
+      "main": [
+        [
+          {
+            "node": "OpenAI",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "OpenAI": {
+      "main": [
+        [
+          {
+            "node": "Upload to SharePoint",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Upload to SharePoint": {
+      "main": [
+        [
+          {
+            "node": "Respond to Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {}
+}

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --production
+COPY . .
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Quote Assistant</title>
+  <script src="https://alcdn.msauth.net/browser/2.32.1/js/msal-browser.min.js" integrity="sha384-v2cZTHbKx4nHCqB6f+GO6zkRgZNpmjDoE7YQDdyCjTiMQuuLHfoalvVYLRNvKcJx" crossorigin="anonymous"></script>
+</head>
+<body>
+  <button id="signin">Sign in with Microsoft</button>
+  <div id="app" style="display:none;">
+    <textarea id="prompt" placeholder="Enter project details"></textarea><br />
+    <input type="file" id="file" />
+    <button id="submit">Submit</button>
+    <pre id="output"></pre>
+  </div>
+  <script>
+    const msalConfig = {
+      auth: {
+        clientId: '{{AAD_CLIENT_ID}}',
+        authority: 'https://login.microsoftonline.com/{{AAD_TENANT_ID}}'
+      }
+    };
+    const msalInstance = new msal.PublicClientApplication(msalConfig);
+    let account = null;
+    const signInButton = document.getElementById('signin');
+    const appDiv = document.getElementById('app');
+    signInButton.onclick = () => {
+      msalInstance.loginPopup({ scopes: ['User.Read'] }).then((resp) => {
+        account = resp.account;
+        signInButton.style.display = 'none';
+        appDiv.style.display = 'block';
+      }).catch(err => alert(err));
+    };
+
+    document.getElementById('submit').onclick = () => {
+      const prompt = document.getElementById('prompt').value;
+      const fileInput = document.getElementById('file');
+      const formData = new FormData();
+      formData.append('prompt', prompt);
+      if (fileInput.files[0]) {
+        formData.append('file', fileInput.files[0]);
+      }
+      formData.append('userEmail', account ? account.username : '');
+      fetch('{{N8N_WEBHOOK_URL}}', {
+        method: 'POST',
+        body: formData
+      })
+      .then(res => res.json())
+      .then(data => {
+        document.getElementById('output').textContent = data.gptOutput || JSON.stringify(data, null, 2);
+      })
+      .catch(err => {
+        document.getElementById('output').textContent = err.toString();
+      });
+    };
+  </script>
+</body>
+</html>

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "quote-webapp",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/web/server.js
+++ b/web/server.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.get('/', (req, res) => {
+  const indexPath = path.join(__dirname, 'index.html');
+  let html = fs.readFileSync(indexPath, 'utf8');
+  html = html.replace('{{N8N_WEBHOOK_URL}}', process.env.N8N_WEBHOOK_URL || '');
+  html = html.replace('{{AAD_CLIENT_ID}}', process.env.AAD_CLIENT_ID || '');
+  html = html.replace('{{AAD_TENANT_ID}}', process.env.AAD_TENANT_ID || '');
+  res.send(html);
+});
+
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- Add Docker stack for quote web front end and Cloudflare tunnel
- Implement Node/Express front end with Microsoft sign-in and n8n webhook submission
- Provide n8n workflow JSON for Autotask lookup, OpenAI call, SharePoint upload, and webhook response
- Document deployment and usage steps

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/express)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b87e6eb6dc832aa6e93ad94c1dee38